### PR TITLE
Add type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.9
+  rev: v0.15.10
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -9,3 +9,14 @@ repos:
   rev: v0.48.0
   hooks:
   - id: markdownlint
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.20.1
+  hooks:
+  - id: mypy
+    # Override upstream args to omit --ignore-missing-imports on purpose.
+    args: ["--scripts-are-modules"]
+    # Let mypy own target selection so hook and standalone runs use the same files.
+    pass_filenames: false
+    additional_dependencies:
+    - pytest
+    - types-lxml

--- a/ammcpc/__init__.py
+++ b/ammcpc/__init__.py
@@ -1,5 +1,5 @@
 from .ammcpc import MediaConchPolicyCheckerCommand
 
 __all__ = [
-    MediaConchPolicyCheckerCommand,
+    "MediaConchPolicyCheckerCommand",
 ]

--- a/ammcpc/ammcpc.py
+++ b/ammcpc/ammcpc.py
@@ -36,6 +36,8 @@ import sys
 import tempfile
 import uuid
 from collections import namedtuple
+from typing import Literal
+from typing import TypedDict
 
 from lxml import etree
 
@@ -51,6 +53,22 @@ class MediaConchException(Exception):
 
 
 Parse = namedtuple("Parse", "etree_el stdout")
+PolicyOutcome = tuple[str, str]
+PolicyCheckResult = tuple[str, str, str, str]
+
+
+class PolicyChecksV03(TypedDict):
+    mc_version: Literal["0.3"]
+    policies: list[PolicyOutcome]
+    root_policy: PolicyOutcome
+
+
+class PolicyChecksV01(TypedDict):
+    mc_version: Literal["0.1"]
+    policy_checks: dict[str, PolicyCheckResult]
+
+
+PolicyChecks = PolicyChecksV03 | PolicyChecksV01
 
 
 class MediaConchPolicyCheckerCommand:
@@ -65,13 +83,19 @@ class MediaConchPolicyCheckerCommand:
         >>> checker.check('/path/to/file-to-be-checked')
     """
 
-    def __init__(self, policy_file_path=None, policy=None, policy_file_name=None):
+    def __init__(
+        self,
+        policy_file_path: str | None = None,
+        policy: str | None = None,
+        policy_file_name: str | None = None,
+    ) -> None:
         self._policy_file_path = policy_file_path
         self._policy = policy
         self._policy_file_name = policy_file_name
-        self.policy_file_name = None
+        self.policy: str | None = None
+        self.policy_file_name: str | None = None
 
-    def check(self, target):
+    def check(self, target: str) -> int:
         """Return 0 if MediaConch can successfully assess whether the file at
         `target` passes the policy checks that are relevant to it, given its
         purpose and the state of the FPR. Parse the XML output by MediaConch
@@ -98,7 +122,7 @@ class MediaConchPolicyCheckerCommand:
         except MediaConchException as exc:
             return self._error(exc)
 
-    def _validate(self):
+    def _validate(self) -> None:
         if self._policy_file_path:
             if not os.path.isfile(self._policy_file_path):
                 raise MediaConchException(
@@ -116,7 +140,7 @@ class MediaConchPolicyCheckerCommand:
                 " the text of the policy and its name as strings."
             )
 
-    def _parse_mediaconch_output(self, target):
+    def _parse_mediaconch_output(self, target: str) -> Parse:
         """Run ``mediaconch -mc -fx -p <path_to_policy_xsl_file>
         <target>`` against the file at ``path_to_target`` and return an lxml
         etree parse of the output.
@@ -133,10 +157,14 @@ class MediaConchPolicyCheckerCommand:
                 ]
                 output = subprocess.check_output(args)
             else:
+                if self.policy is None or self.policy_file_name is None:
+                    raise MediaConchException(
+                        "Internal error: policy state was not validated before parsing."
+                    )
                 ext = os.path.splitext(self.policy_file_name)[1]
                 pfp = tempfile.NamedTemporaryFile(suffix=ext, delete=False)
                 try:
-                    pfp.write(self._policy.encode("utf8"))
+                    pfp.write(self.policy.encode("utf8"))
                     pfp.close()
                     args = ["mediaconch", "-mc", "-fx", "-p", pfp.name, target]
                     output = subprocess.check_output(args)
@@ -151,12 +179,13 @@ class MediaConchPolicyCheckerCommand:
         try:
             return Parse(etree_el=etree.fromstring(output), stdout=output)
         except etree.XMLSyntaxError:
+            output_s = output.decode(errors="backslashreplace")
             raise MediaConchException(
                 "The MediaConch command failed when attempting to parse the"
-                f" XML output by MediaConch:\n\n {output}"
+                f" XML output by MediaConch:\n\n {output_s}"
             )
 
-    def _get_evt_out_inf_detail(self, policy_checks):
+    def _get_evt_out_inf_detail(self, policy_checks: PolicyChecks) -> tuple[str, str]:
         """Return a 2-tuple of info and detail.
         - info: 'pass' or 'fail'
         - detail: human-readable string indicating which policy checks
@@ -167,7 +196,9 @@ class MediaConchPolicyCheckerCommand:
             return self._get_evt_out_inf_detail_v_0_3(policy_checks)
         return self._get_evt_out_inf_detail_v_0_1(policy_checks)
 
-    def _get_evt_out_inf_detail_v_0_3(self, policy_checks):
+    def _get_evt_out_inf_detail_v_0_3(
+        self, policy_checks: PolicyChecksV03
+    ) -> tuple[str, str]:
         failed_policy_checks = set()
         passed_policy_checks = set()
         info = "fail"
@@ -196,7 +227,9 @@ class MediaConchPolicyCheckerCommand:
             f"{prefix} No checks passed, but none failed either.",
         )
 
-    def _get_evt_out_inf_detail_v_0_1(self, policy_checks):
+    def _get_evt_out_inf_detail_v_0_1(
+        self, policy_checks: PolicyChecksV01
+    ) -> tuple[str, str]:
         failed_policy_checks = set()
         passed_policy_checks = set()
         for name, (out, fie, act, rea) in policy_checks["policy_checks"].items():
@@ -226,7 +259,7 @@ class MediaConchPolicyCheckerCommand:
             f"{prefix} No checks passed, but none failed either.",
         )
 
-    def _error(self, exc):
+    def _error(self, exc: MediaConchException) -> int:
         try:
             pfn = self.policy_file_name
             pol = self.policy
@@ -247,12 +280,14 @@ class MediaConchPolicyCheckerCommand:
         return ERROR_CODE
 
 
-def _get_policy_check_name(policy_check_el):
+def _get_policy_check_name(policy_check_el: etree._Element) -> str:
     return policy_check_el.attrib.get("name", "Unnamed Check %s" % uuid.uuid4())
 
 
-def _parse_policy_check_test(policy_check_el):
-    """Return a 3-tuple parse of the <test> element of the policy <check>
+def _parse_policy_check_test(
+    policy_check_el: etree._Element,
+) -> PolicyCheckResult | None:
+    """Return a 4-tuple parse of the <test> element of the policy <check>
     element.
 
     - El1 is outcome ("pass" or "fail" or other?)
@@ -275,15 +310,19 @@ def _parse_policy_check_test(policy_check_el):
     )
 
 
-def _get_policy_checks_v_0_3(doc):
-    policy_checks = {"mc_version": "0.3", "policies": []}
+def _get_policy_checks_v_0_3(doc: etree._Element) -> PolicyChecksV03:
     root_policy = doc.find(f".{NS}media/{NS}policy")
     if root_policy is None:
         raise MediaConchException("Unable to find a root policy")
-    policy_checks["root_policy"] = (
+    root_policy_outcome: PolicyOutcome = (
         root_policy.attrib.get("name", "No root policy name"),
         root_policy.attrib.get("outcome", "No root policy outcome"),
     )
+    policy_checks: PolicyChecksV03 = {
+        "mc_version": "0.3",
+        "policies": [],
+        "root_policy": root_policy_outcome,
+    }
     for el_tname in ("policy", "rule"):
         path = f".//{NS}{el_tname}"
         for policy_el in doc.iterfind(path):
@@ -294,8 +333,8 @@ def _get_policy_checks_v_0_3(doc):
     return policy_checks
 
 
-def _get_policy_checks_v_0_1(doc):
-    policy_checks = {"mc_version": "0.1", "policy_checks": {}}
+def _get_policy_checks_v_0_1(doc: etree._Element) -> PolicyChecksV01:
+    policy_checks: PolicyChecksV01 = {"mc_version": "0.1", "policy_checks": {}}
     path = f".{NS}media/{NS}policyChecks/{NS}check"
     for policy_check_el in doc.iterfind(path):
         policy_check_name = _get_policy_check_name(policy_check_el)
@@ -305,7 +344,7 @@ def _get_policy_checks_v_0_1(doc):
     return policy_checks
 
 
-def _get_policy_checks(doc):
+def _get_policy_checks(doc: etree._Element) -> PolicyChecks:
     """Get all of the policy check names and outcomes from the policy check
     output file parsed as ``doc``.
     """
@@ -320,7 +359,7 @@ def _get_policy_checks(doc):
         )
 
 
-def main():
+def main() -> None:
     target = sys.argv[1]
     policy = sys.argv[2]
     policy_checker = MediaConchPolicyCheckerCommand(policy_file_path=policy)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,13 @@ ammcpc = "ammcpc.ammcpc:main"
 [project.optional-dependencies]
 dev = [
   "coverage",
+  "mypy",
   "pip-tools",
   "pytest-cov",
   "pytest",
   "ruff",
+  "tox",
+  "types-lxml"
 ]
 
 [tool.setuptools.dynamic]
@@ -85,6 +88,10 @@ ignore = [
 
 [tool.ruff.lint.isort]
 force-single-line = true
+
+[tool.mypy]
+strict = true
+files = ["ammcpc", "tests"]
 
 [tool.pytest.ini_options]
 python_files = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,53 +4,113 @@
 #
 #    pip-compile --allow-unsafe --extra=dev --output-file=requirements-dev.txt pyproject.toml
 #
-build==1.4.2
+beautifulsoup4==4.14.3
+    # via types-lxml
+build==1.4.3
     # via pip-tools
+cachetools==7.0.5
+    # via tox
 click==8.3.2
     # via pip-tools
+colorama==0.4.6
+    # via tox
 coverage[toml]==7.13.5
     # via
     #   ammcpc (pyproject.toml)
     #   pytest-cov
+cssselect==1.4.0
+    # via types-lxml
+distlib==0.4.0
+    # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
+filelock==3.28.0
+    # via
+    #   python-discovery
+    #   tox
+    #   virtualenv
 iniconfig==2.3.0
     # via pytest
-lxml==6.0.2
+librt==0.9.0
+    # via mypy
+lxml==6.0.4
     # via ammcpc (pyproject.toml)
-packaging==26.0
+mypy==1.20.1
+    # via ammcpc (pyproject.toml)
+mypy-extensions==1.1.0
+    # via mypy
+packaging==26.1
     # via
     #   build
+    #   pyproject-api
     #   pytest
+    #   tox
     #   wheel
+pathspec==1.0.4
+    # via mypy
 pip-tools==7.5.3
     # via ammcpc (pyproject.toml)
+platformdirs==4.9.6
+    # via
+    #   python-discovery
+    #   tox
+    #   virtualenv
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
+    #   tox
 pygments==2.20.0
     # via pytest
+pyproject-api==1.10.0
+    # via tox
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   ammcpc (pyproject.toml)
     #   pytest-cov
 pytest-cov==7.1.0
     # via ammcpc (pyproject.toml)
-ruff==0.15.9
+python-discovery==1.2.2
+    # via
+    #   tox
+    #   virtualenv
+ruff==0.15.10
     # via ammcpc (pyproject.toml)
+soupsieve==2.8.3
+    # via beautifulsoup4
 tomli==2.4.1
     # via
     #   build
     #   coverage
+    #   mypy
     #   pip-tools
+    #   pyproject-api
     #   pytest
+    #   tox
+tomli-w==1.2.0
+    # via tox
+tox==4.53.0
+    # via ammcpc (pyproject.toml)
+types-html5lib==1.1.11.20260408
+    # via types-lxml
+types-lxml==2026.2.16
+    # via ammcpc (pyproject.toml)
+types-webencodings==0.5.0.20260408
+    # via types-html5lib
 typing-extensions==4.15.0
-    # via exceptiongroup
+    # via
+    #   beautifulsoup4
+    #   exceptiongroup
+    #   mypy
+    #   tox
+    #   types-lxml
+    #   virtualenv
+virtualenv==21.2.4
+    # via tox
 wheel==0.46.3
     # via pip-tools
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.txt pyproject.toml
 #
-lxml==6.0.2
+lxml==6.0.4
     # via ammcpc (pyproject.toml)

--- a/tests/test_ammcpc.py
+++ b/tests/test_ammcpc.py
@@ -1,5 +1,7 @@
 import json
 import os
+import pathlib
+from collections.abc import Generator
 from unittest import mock
 
 import pytest
@@ -207,7 +209,7 @@ XML_PASSED_CHECK_OUTPUT = """
 
 
 @pytest.fixture
-def mediaconch_fails():
+def mediaconch_fails() -> Generator[None, None, None]:
     with mock.patch(
         "subprocess.check_output",
         side_effect=[
@@ -219,7 +221,7 @@ def mediaconch_fails():
 
 
 @pytest.fixture
-def mediaconch_passes():
+def mediaconch_passes() -> Generator[None, None, None]:
     with mock.patch(
         "subprocess.check_output",
         side_effect=[
@@ -230,7 +232,9 @@ def mediaconch_passes():
         yield
 
 
-def test_check_bad_file(mediaconch_fails, capsys):
+def test_check_bad_file(
+    mediaconch_fails: None, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Expect a policy check on a failing file to return a 0 exit code and
     print to stdout a JSON object with a 'eventOutcomeInformation'
     attribute whose value is 'fail'.
@@ -253,7 +257,9 @@ def test_check_bad_file(mediaconch_fails, capsys):
         assert output["policy"] == filei.read()
 
 
-def test_check_bad_file_str_pol(mediaconch_fails, capsys):
+def test_check_bad_file_str_pol(
+    mediaconch_fails: None, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Same as ``test_check_bad_file`` except that the policy is passed as
     a string.
     """
@@ -281,7 +287,9 @@ def test_check_bad_file_str_pol(mediaconch_fails, capsys):
     assert output["policy"] == policy
 
 
-def test_check_good_file(mediaconch_passes, capsys):
+def test_check_good_file(
+    mediaconch_passes: None, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Expect a policy check on a passing file to return a 0 exit code and
     print to stdout a JSON object with a 'eventOutcomeInformation'
     attribute whose value is 'pass'.
@@ -304,7 +312,9 @@ def test_check_good_file(mediaconch_passes, capsys):
         assert output["policy"] == filei.read()
 
 
-def test_check_good_file_str_pol(mediaconch_passes, capsys):
+def test_check_good_file_str_pol(
+    mediaconch_passes: None, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Same as ``test_check_good_file`` except that the policy is passed as
     a string.
     """
@@ -332,7 +342,7 @@ def test_check_good_file_str_pol(mediaconch_passes, capsys):
     assert output["policy"] == policy
 
 
-def test_no_policy(capsys, tmp_path):
+def test_no_policy(capsys: pytest.CaptureFixture[str], tmp_path: pathlib.Path) -> None:
     """Expect a 1 exit code and a fail outcome when the policy file does
     not exist.
     """


### PR DESCRIPTION
This adds inline type annotations across the main ammcpc code and tests, enables strict mypy, and integrates type checking into pre-commit.